### PR TITLE
Swift types are all automatically namespaced by the module that contains...

### DIFF
--- a/AeroGearHttp.xcodeproj/project.pbxproj
+++ b/AeroGearHttp.xcodeproj/project.pbxproj
@@ -7,17 +7,17 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		4840C2AD196D5CBE00065270 /* AGRequestSerializerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4840C2AC196D5CBE00065270 /* AGRequestSerializerTest.swift */; };
-		48866966197054BF00579654 /* AGResponseSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48866965197054BF00579654 /* AGResponseSerializer.swift */; };
-		48866968197054CD00579654 /* AGResponseSerializerImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48866967197054CD00579654 /* AGResponseSerializerImpl.swift */; };
+		4840C2AD196D5CBE00065270 /* RequestSerializerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4840C2AC196D5CBE00065270 /* RequestSerializerTest.swift */; };
+		48866966197054BF00579654 /* ResponseSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48866965197054BF00579654 /* ResponseSerializer.swift */; };
+		48866968197054CD00579654 /* ResponseSerializerImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48866967197054CD00579654 /* ResponseSerializerImpl.swift */; };
 		488B6B62196B19BC000297C9 /* AeroGearHttp.h in Headers */ = {isa = PBXBuildFile; fileRef = 488B6B61196B19BC000297C9 /* AeroGearHttp.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		488B6B6F196B19BC000297C9 /* AGSessionImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488B6B6E196B19BC000297C9 /* AGSessionImplTests.swift */; };
-		488B6B7E196B1A0F000297C9 /* AGSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488B6B7A196B1A0F000297C9 /* AGSession.swift */; };
+		488B6B6F196B19BC000297C9 /* SessionImplTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488B6B6E196B19BC000297C9 /* SessionImplTests.swift */; };
+		488B6B7E196B1A0F000297C9 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488B6B7A196B1A0F000297C9 /* Session.swift */; };
 		488B6B84196B1CD1000297C9 /* AeroGearHttp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 488B6B5C196B19BC000297C9 /* AeroGearHttp.framework */; };
-		488B6B90196B25D3000297C9 /* AGHttpMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488B6B8F196B25D3000297C9 /* AGHttpMethod.swift */; };
-		488B6B92196C0993000297C9 /* AGRequestSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488B6B91196C0993000297C9 /* AGRequestSerializer.swift */; };
-		488B6B94196C09C9000297C9 /* AGRequestSerializerImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488B6B93196C09C9000297C9 /* AGRequestSerializerImpl.swift */; };
-		488B6B96196C315B000297C9 /* AGSessionImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488B6B95196C315B000297C9 /* AGSessionImpl.swift */; };
+		488B6B90196B25D3000297C9 /* HttpMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488B6B8F196B25D3000297C9 /* HttpMethod.swift */; };
+		488B6B92196C0993000297C9 /* RequestSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488B6B91196C0993000297C9 /* RequestSerializer.swift */; };
+		488B6B94196C09C9000297C9 /* RequestSerializerImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488B6B93196C09C9000297C9 /* RequestSerializerImpl.swift */; };
+		488B6B96196C315B000297C9 /* SessionImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488B6B95196C315B000297C9 /* SessionImpl.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -66,20 +66,20 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		4840C2AC196D5CBE00065270 /* AGRequestSerializerTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AGRequestSerializerTest.swift; sourceTree = "<group>"; };
-		48866965197054BF00579654 /* AGResponseSerializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AGResponseSerializer.swift; sourceTree = "<group>"; };
-		48866967197054CD00579654 /* AGResponseSerializerImpl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AGResponseSerializerImpl.swift; sourceTree = "<group>"; };
+		4840C2AC196D5CBE00065270 /* RequestSerializerTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestSerializerTest.swift; sourceTree = "<group>"; };
+		48866965197054BF00579654 /* ResponseSerializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResponseSerializer.swift; sourceTree = "<group>"; };
+		48866967197054CD00579654 /* ResponseSerializerImpl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResponseSerializerImpl.swift; sourceTree = "<group>"; };
 		488B6B5C196B19BC000297C9 /* AeroGearHttp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AeroGearHttp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		488B6B60196B19BC000297C9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		488B6B61196B19BC000297C9 /* AeroGearHttp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AeroGearHttp.h; sourceTree = "<group>"; };
 		488B6B67196B19BC000297C9 /* AeroGearHttpTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AeroGearHttpTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		488B6B6D196B19BC000297C9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		488B6B6E196B19BC000297C9 /* AGSessionImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AGSessionImplTests.swift; sourceTree = "<group>"; };
-		488B6B7A196B1A0F000297C9 /* AGSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AGSession.swift; sourceTree = "<group>"; };
-		488B6B8F196B25D3000297C9 /* AGHttpMethod.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AGHttpMethod.swift; sourceTree = "<group>"; };
-		488B6B91196C0993000297C9 /* AGRequestSerializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AGRequestSerializer.swift; sourceTree = "<group>"; };
-		488B6B93196C09C9000297C9 /* AGRequestSerializerImpl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AGRequestSerializerImpl.swift; sourceTree = "<group>"; };
-		488B6B95196C315B000297C9 /* AGSessionImpl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AGSessionImpl.swift; sourceTree = "<group>"; };
+		488B6B6E196B19BC000297C9 /* SessionImplTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionImplTests.swift; sourceTree = "<group>"; };
+		488B6B7A196B1A0F000297C9 /* Session.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
+		488B6B8F196B25D3000297C9 /* HttpMethod.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HttpMethod.swift; sourceTree = "<group>"; };
+		488B6B91196C0993000297C9 /* RequestSerializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestSerializer.swift; sourceTree = "<group>"; };
+		488B6B93196C09C9000297C9 /* RequestSerializerImpl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestSerializerImpl.swift; sourceTree = "<group>"; };
+		488B6B95196C315B000297C9 /* SessionImpl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionImpl.swift; sourceTree = "<group>"; };
 		48F463E519A4C32E002858E0 /* AGURLSessionStubs.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = AGURLSessionStubs.xcodeproj; path = "aerogear-ios-httpstub/AGURLSessionStubs.xcodeproj"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -105,9 +105,9 @@
 		4809D8B7196D75AD00724AFC /* internal */ = {
 			isa = PBXGroup;
 			children = (
-				488B6B95196C315B000297C9 /* AGSessionImpl.swift */,
-				488B6B93196C09C9000297C9 /* AGRequestSerializerImpl.swift */,
-				48866967197054CD00579654 /* AGResponseSerializerImpl.swift */,
+				488B6B95196C315B000297C9 /* SessionImpl.swift */,
+				488B6B93196C09C9000297C9 /* RequestSerializerImpl.swift */,
+				48866967197054CD00579654 /* ResponseSerializerImpl.swift */,
 			);
 			name = internal;
 			sourceTree = "<group>";
@@ -134,10 +134,10 @@
 			isa = PBXGroup;
 			children = (
 				4809D8B7196D75AD00724AFC /* internal */,
-				488B6B8F196B25D3000297C9 /* AGHttpMethod.swift */,
-				488B6B7A196B1A0F000297C9 /* AGSession.swift */,
-				488B6B91196C0993000297C9 /* AGRequestSerializer.swift */,
-				48866965197054BF00579654 /* AGResponseSerializer.swift */,
+				488B6B8F196B25D3000297C9 /* HttpMethod.swift */,
+				488B6B7A196B1A0F000297C9 /* Session.swift */,
+				488B6B91196C0993000297C9 /* RequestSerializer.swift */,
+				48866965197054BF00579654 /* ResponseSerializer.swift */,
 				488B6B61196B19BC000297C9 /* AeroGearHttp.h */,
 				488B6B5F196B19BC000297C9 /* Supporting Files */,
 			);
@@ -156,8 +156,8 @@
 			isa = PBXGroup;
 			children = (
 				48F463E519A4C32E002858E0 /* AGURLSessionStubs.xcodeproj */,
-				488B6B6E196B19BC000297C9 /* AGSessionImplTests.swift */,
-				4840C2AC196D5CBE00065270 /* AGRequestSerializerTest.swift */,
+				488B6B6E196B19BC000297C9 /* SessionImplTests.swift */,
+				4840C2AC196D5CBE00065270 /* RequestSerializerTest.swift */,
 				488B6B6C196B19BC000297C9 /* Supporting Files */,
 			);
 			path = AeroGearHttpTests;
@@ -314,13 +314,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				488B6B90196B25D3000297C9 /* AGHttpMethod.swift in Sources */,
-				488B6B94196C09C9000297C9 /* AGRequestSerializerImpl.swift in Sources */,
-				48866966197054BF00579654 /* AGResponseSerializer.swift in Sources */,
-				488B6B7E196B1A0F000297C9 /* AGSession.swift in Sources */,
-				488B6B96196C315B000297C9 /* AGSessionImpl.swift in Sources */,
-				488B6B92196C0993000297C9 /* AGRequestSerializer.swift in Sources */,
-				48866968197054CD00579654 /* AGResponseSerializerImpl.swift in Sources */,
+				488B6B90196B25D3000297C9 /* HttpMethod.swift in Sources */,
+				488B6B94196C09C9000297C9 /* RequestSerializerImpl.swift in Sources */,
+				48866966197054BF00579654 /* ResponseSerializer.swift in Sources */,
+				488B6B7E196B1A0F000297C9 /* Session.swift in Sources */,
+				488B6B96196C315B000297C9 /* SessionImpl.swift in Sources */,
+				488B6B92196C0993000297C9 /* RequestSerializer.swift in Sources */,
+				48866968197054CD00579654 /* ResponseSerializerImpl.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -328,8 +328,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				488B6B6F196B19BC000297C9 /* AGSessionImplTests.swift in Sources */,
-				4840C2AD196D5CBE00065270 /* AGRequestSerializerTest.swift in Sources */,
+				488B6B6F196B19BC000297C9 /* SessionImplTests.swift in Sources */,
+				4840C2AD196D5CBE00065270 /* RequestSerializerTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AeroGearHttp/HttpMethod.swift
+++ b/AeroGearHttp/HttpMethod.swift
@@ -17,7 +17,11 @@
 
 import Foundation
 
-protocol AGResponseSerializer {    
-    func response(data: NSData) -> (AnyObject?)
-    func validateResponse(response: NSURLResponse!, data: NSData!, inout error: NSError) -> Bool
+
+public enum HttpMethod: String {
+    case GET = "GET"
+    case HEAD = "HEAD"
+    case DELETE = "DELETE"
+    case POST = "POST"
+    case PUT = "PUT"
 }

--- a/AeroGearHttp/RequestSerializer.swift
+++ b/AeroGearHttp/RequestSerializer.swift
@@ -17,7 +17,7 @@
 
 import Foundation
 
-protocol AGRequestSerializer {
+protocol RequestSerializer {
     var url: NSURL {get set}
     var headers: Dictionary<String, String> {get set}
     var stringEncoding: NSNumber {get}
@@ -25,6 +25,6 @@ protocol AGRequestSerializer {
     var timeoutInterval: NSTimeInterval {get set}
     var boundary: String {get}
     
-    func request(method: AGHttpMethod, parameters: [String: AnyObject]?) -> NSURLRequest?
-    func multiPartRequest(method: AGHttpMethod) -> NSURLRequest?
+    func request(method: HttpMethod, parameters: [String: AnyObject]?) -> NSURLRequest?
+    func multiPartRequest(method: HttpMethod) -> NSURLRequest?
 }

--- a/AeroGearHttp/RequestSerializerImpl.swift
+++ b/AeroGearHttp/RequestSerializerImpl.swift
@@ -17,7 +17,7 @@
 
 import Foundation
 
-public class AGRequestSerializerImpl  : AGRequestSerializer {
+public class RequestSerializerImpl  : RequestSerializer {
     var url: NSURL
     var headers: [String: String]
     var stringEncoding: NSNumber
@@ -33,7 +33,7 @@ public class AGRequestSerializerImpl  : AGRequestSerializer {
         self.cachePolicy = .UseProtocolCachePolicy
     }
     
-    public func request(method: AGHttpMethod, parameters: [String: AnyObject]?) -> NSURLRequest? {
+    public func request(method: HttpMethod, parameters: [String: AnyObject]?) -> NSURLRequest? {
         var request = NSMutableURLRequest(URL: url, cachePolicy: cachePolicy, timeoutInterval: timeoutInterval)
         request.HTTPMethod = method.toRaw()
         
@@ -46,7 +46,7 @@ public class AGRequestSerializerImpl  : AGRequestSerializer {
             queryString = self.stringFromParameters(parameters!)
         }
 
-        if method == AGHttpMethod.GET || method == AGHttpMethod.HEAD || method == AGHttpMethod.DELETE {
+        if method == HttpMethod.GET || method == HttpMethod.HEAD || method == HttpMethod.DELETE {
             var paramSeparator = request.URL.query != nil ? "&" : "?"
             var newUrl:String
             if (request.URL?.absoluteString != nil) {
@@ -64,7 +64,7 @@ public class AGRequestSerializerImpl  : AGRequestSerializer {
         return request
     }
     
-    public func multiPartRequest(method: AGHttpMethod) -> NSURLRequest? {
+    public func multiPartRequest(method: HttpMethod) -> NSURLRequest? {
         assert(method == .POST || method == .PUT, "PUT or POST only")
         var request = NSMutableURLRequest(URL: url, cachePolicy: cachePolicy, timeoutInterval: timeoutInterval)
         request.HTTPMethod = method.toRaw()

--- a/AeroGearHttp/ResponseSerializer.swift
+++ b/AeroGearHttp/ResponseSerializer.swift
@@ -17,11 +17,7 @@
 
 import Foundation
 
-
-public enum AGHttpMethod: String {
-    case GET = "GET"
-    case HEAD = "HEAD"
-    case DELETE = "DELETE"
-    case POST = "POST"
-    case PUT = "PUT"
+protocol ResponseSerializer {    
+    func response(data: NSData) -> (AnyObject?)
+    func validateResponse(response: NSURLResponse!, data: NSData!, inout error: NSError) -> Bool
 }

--- a/AeroGearHttp/ResponseSerializerImpl.swift
+++ b/AeroGearHttp/ResponseSerializerImpl.swift
@@ -17,10 +17,10 @@
 
 import Foundation
 
-let AGHtttpResponseSerializationErrorDomain = "org.aerogear.http.response";
+let HtttpResponseSerializationErrorDomain = "org.aerogear.http.response";
 
 
-class AGResponseSerializerImpl : AGResponseSerializer {
+class ResponseSerializerImpl : ResponseSerializer {
     
     func response(data: NSData) -> (AnyObject?) {
         return NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions(0), error: nil)
@@ -37,7 +37,7 @@ class AGResponseSerializerImpl : AGResponseSerializer {
                 NSURLErrorFailingURLErrorKey: httpResponse.URL
             ]
             
-            error = NSError(domain: AGHtttpResponseSerializationErrorDomain, code: httpResponse.statusCode, userInfo: userInfo)
+            error = NSError(domain: HtttpResponseSerializationErrorDomain, code: httpResponse.statusCode, userInfo: userInfo)
         }
         
         return isValid

--- a/AeroGearHttp/Session.swift
+++ b/AeroGearHttp/Session.swift
@@ -18,12 +18,12 @@
 import Foundation
 
 
-protocol AGSession {
+protocol Session {
     
     var baseURL: NSURL {get set}
     var session: NSURLSession {get set}
-    var requestSerializer: AGRequestSerializer! {get set}
-    var responseSerializer: AGResponseSerializer! {get set}
+    var requestSerializer: RequestSerializer! {get set}
+    var responseSerializer: ResponseSerializer! {get set}
     
     func GET(parameters: [String: AnyObject]?, success:((AnyObject?) -> Void)!, failure:((NSError) -> Void)!) -> Void
     func POST(parameters: [String: AnyObject]?, success:((AnyObject?) -> Void)!, failure:((NSError) -> Void)!) -> Void

--- a/AeroGearHttp/SessionImpl.swift
+++ b/AeroGearHttp/SessionImpl.swift
@@ -17,11 +17,11 @@
 
 import Foundation
 
-public class AGSessionImpl : AGSession {
+public class SessionImpl : Session {
     var baseURL: NSURL
     var session: NSURLSession
-    var requestSerializer: AGRequestSerializer!
-    var responseSerializer: AGResponseSerializer!
+    var requestSerializer: RequestSerializer!
+    var responseSerializer: ResponseSerializer!
     
     public convenience init(url: String) {
         let baseURL = NSURL.URLWithString(url)
@@ -30,17 +30,17 @@ public class AGSessionImpl : AGSession {
     
     public convenience init(url: String, sessionConfig: NSURLSessionConfiguration?) {
         let baseURL = NSURL.URLWithString(url)
-        self.init(url: url, sessionConfig: sessionConfig, requestSerializer: AGRequestSerializerImpl(url: baseURL, headers: [String: String]()), responseSerializer: AGResponseSerializerImpl())
+        self.init(url: url, sessionConfig: sessionConfig, requestSerializer: RequestSerializerImpl(url: baseURL, headers: [String: String]()), responseSerializer: ResponseSerializerImpl())
     }
     
-    init(url: String, sessionConfig: NSURLSessionConfiguration?, requestSerializer: AGRequestSerializer, responseSerializer: AGResponseSerializer) {
+    init(url: String, sessionConfig: NSURLSessionConfiguration?, requestSerializer: RequestSerializer, responseSerializer: ResponseSerializer) {
         self.baseURL = NSURL.URLWithString(url)
         self.session = (sessionConfig == nil) ? NSURLSession.sharedSession() : NSURLSession(configuration: sessionConfig)
         self.requestSerializer = requestSerializer
         self.responseSerializer = responseSerializer
     }
 
-    func call(url: NSURL, method: AGHttpMethod, parameters: Dictionary<String, AnyObject>?, success:((AnyObject?) -> Void)!, failure:((NSError) -> Void)!) -> Void {
+    func call(url: NSURL, method: HttpMethod, parameters: Dictionary<String, AnyObject>?, success:((AnyObject?) -> Void)!, failure:((NSError) -> Void)!) -> Void {
         
         let serializedRequest = requestSerializer.request(method, parameters: parameters)
         
@@ -119,7 +119,7 @@ public class AGSessionImpl : AGSession {
         for (key, value) in parameters {
             if (value is NSData) {
                 body.appendData("\r\n--\(requestSerializer.boundary)\r\n".dataUsingEncoding(NSUTF8StringEncoding)!)
-                // TODO fileName associated with image similar to AGFilePart
+                // TODO fileName associated with image similar to FilePart
                 body.appendData("Content-Disposition: form-data; name=\"photo\"; filename=\"filename.jpg\"\r\n".dataUsingEncoding(NSUTF8StringEncoding)!)
                 //body
             } else {

--- a/AeroGearHttpTests/RequestSerializerTest.swift
+++ b/AeroGearHttpTests/RequestSerializerTest.swift
@@ -19,7 +19,7 @@
 import XCTest
 import AeroGearHttp
 
-class AGRequestSerializerTests: XCTestCase {
+class RequestSerializerTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
@@ -33,7 +33,7 @@ class AGRequestSerializerTests: XCTestCase {
     
     func testGETWithParameters() {
         var url = NSURL.URLWithString("http://api.icndb.com/jokes/12")
-        var serialiser = AGRequestSerializerImpl(url: url, headers: [String: String]())
+        var serialiser = RequestSerializerImpl(url: url, headers: [String: String]())
         var result = serialiser.request(.GET, parameters: ["param1": "value1", "array": ["one", "two", "three", "four"], "numeric": 5])
         let unwrappedResult = result!
         let expectedString = "http://api.icndb.com/jokes/12?array%5B%5D=one&array%5B%5D=two&array%5B%5D=three&array%5B%5D=four&param1=value1&numeric=5"
@@ -42,7 +42,7 @@ class AGRequestSerializerTests: XCTestCase {
     
     func testMultiPartRequestWithPost() {
         var url = NSURL.URLWithString("http://api.icndb.com/jokes/12")
-        var serialiser = AGRequestSerializerImpl(url: url, headers: [String: String]())
+        var serialiser = RequestSerializerImpl(url: url, headers: [String: String]())
         var result: NSURLRequest = serialiser.multiPartRequest(.POST)!
 
         //XCTAssertTrue(result.description.rangeOfString("multipart/form-data; boundary=BOUNDARY_STRING\";"))

--- a/AeroGearHttpTests/SessionImplTests.swift
+++ b/AeroGearHttpTests/SessionImplTests.swift
@@ -20,7 +20,7 @@ import XCTest
 import AeroGearHttp
 import AGURLSessionStubs
 
-class AGSessionImplTests: XCTestCase {
+class SessionImplTests: XCTestCase {
 
     func http_200(request: NSURLRequest!, params:[String: String]?) -> StubResponse {
         var data: NSData
@@ -55,7 +55,7 @@ class AGSessionImplTests: XCTestCase {
         let getExpectation = expectationWithDescription("Retrieve data with GET without parameters");
         
         var url = "http://whatever.com"
-        var http = AGSessionImpl(url: url, sessionConfig: NSURLSessionConfiguration.defaultSessionConfiguration())
+        var http = SessionImpl(url: url, sessionConfig: NSURLSessionConfiguration.defaultSessionConfiguration())
         http.GET(nil, success: {(response: AnyObject?) in
             if (response != nil) {
                 XCTAssertTrue(response!["key1"] as NSString == "value1")
@@ -78,7 +78,7 @@ class AGSessionImplTests: XCTestCase {
         let getExpectation = expectationWithDescription("Retrieve list of jokes");
         
         var url = "http://api.icndb.com/jokes"
-        var http = AGSessionImpl(url: url, sessionConfig: NSURLSessionConfiguration.defaultSessionConfiguration())
+        var http = SessionImpl(url: url, sessionConfig: NSURLSessionConfiguration.defaultSessionConfiguration())
         http.GET(nil, success: {(response: AnyObject?) in
                 if (response != nil) {
                     getExpectation.fulfill()
@@ -100,7 +100,7 @@ class AGSessionImplTests: XCTestCase {
         let getExpectation = expectationWithDescription("Retrieve list of jokes");
         
         var url = "http://api.icndb.com/jokes/12"
-        var http = AGSessionImpl(url: url, sessionConfig: NSURLSessionConfiguration.defaultSessionConfiguration())
+        var http = SessionImpl(url: url, sessionConfig: NSURLSessionConfiguration.defaultSessionConfiguration())
         http.GET(nil, success: {(response: AnyObject?) in
             if (response != nil) {
                 getExpectation.fulfill()


### PR DESCRIPTION
... them, remove AG prefix

followed this kind of standard
https://github.com/raywenderlich/swift-style-guide#class-prefixes

aligned with ios-httpstub
