### PR TITLE
make authzModule public to access it from oauth2

### DIFF
--- a/AeroGearHttp/Http.swift
+++ b/AeroGearHttp/Http.swift
@@ -70,7 +70,7 @@ public class Http {
     var session: NSURLSession
     var requestSerializer: RequestSerializer
     var responseSerializer: ResponseSerializer
-    var authzModule:  AuthzModule?
+    public var authzModule:  AuthzModule?
     
     private var delegate: SessionDelegate;
     


### PR DESCRIPTION
Ass discussed @cvasilak this attribute need to be public to be visible from oauth2 lib.
