### PR TITLE
pass response data to completionHandler even upon error

### DIFF
--- a/AeroGearHttp/AuthzModule.swift
+++ b/AeroGearHttp/AuthzModule.swift
@@ -27,35 +27,35 @@ public protocol AuthzModule {
     
     :param: completionHandler A block object to be executed when the request operation finishes.
     */
-    func requestAccess(completionHandler: (AnyObject?, NSError?) -> Void)
+    func requestAccess(completionHandler: (NSHTTPURLResponse?, NSError?, AnyObject?) -> Void)
 
     /**
     Request an authorization code
     
     :param: completionHandler A block object to be executed when the request operation finishes.
     */
-    func requestAuthorizationCode(completionHandler: (AnyObject?, NSError?) -> Void)
+    func requestAuthorizationCode(completionHandler: (NSHTTPURLResponse?, NSError?, AnyObject?) -> Void)
 
     /**
     Exchange an authorization code for an access token
     
     :param: completionHandler A block object to be executed when the request operation finishes.
     */
-    func exchangeAuthorizationCodeForAccessToken(code: String, completionHandler: (AnyObject?, NSError?) -> Void)
+    func exchangeAuthorizationCodeForAccessToken(code: String, completionHandler: (NSHTTPURLResponse?, NSError?, AnyObject?) -> Void)
     
     /**
     Request to refresh an access token
     
     :param: completionHandler A block object to be executed when the request operation finishes.
     */
-    func refreshAccessToken(completionHandler: (AnyObject?, NSError?) -> Void)
+    func refreshAccessToken(completionHandler: (NSHTTPURLResponse?, NSError?, AnyObject?) -> Void)
     
     /**
     Request to revoke access
     
     :param: completionHandler A block object to be executed when the request operation finishes.
     */
-    func revokeAccess(completionHandler: (AnyObject?, NSError?) -> Void)
+    func revokeAccess(completionHandler: (NSHTTPURLResponse?, NSError?, AnyObject?) -> Void)
     
     /**
     Return any authorization fields

--- a/AeroGearHttp/Http.swift
+++ b/AeroGearHttp/Http.swift
@@ -512,14 +512,15 @@ public class Http {
             
             var error: NSError?
             var isValid = self.responseSerializer?.validateResponse(response, data: data!, error: &error)
+            var responseObject: AnyObject? = self.responseSerializer?.response(data!)
             
             if (isValid == false) {
-                completionHandler?(nil, error)
+                completionHandler?(responseObject, error)
                 return
             }
             
             if (data != nil) {
-                var responseObject: AnyObject? = self.responseSerializer?.response(data!)
+                
                 completionHandler?(responseObject, nil)
             }
         }

--- a/AeroGearHttp/JsonRequestSerializer.swift
+++ b/AeroGearHttp/JsonRequestSerializer.swift
@@ -40,6 +40,13 @@ public class JsonRequestSerializer:  HttpRequestSerializer {
                     request.HTTPBody = body
                 }
             }
+            
+            // apply headers to new request
+            if(headers != nil) {
+                for (key,val) in headers! {
+                    request.addValue(val, forHTTPHeaderField: key)
+                }
+            }
 
             return request
         }


### PR DESCRIPTION
Upon server error some information about error itself may come in data field of response. This change passes this data even upon error! In this case the client code can check for error in this way:

```
http.POST("login", parameters: params, completionHandler: {(response, error) in 
    if(error != nil) {
        println(response) // print response data that may describe the error.
    }
})
```