### PR TITLE
switch to XCTAssertTrue assertion

### DIFF
--- a/AeroGearHttpTests/JSONRequestSerializerTest.swift
+++ b/AeroGearHttpTests/JSONRequestSerializerTest.swift
@@ -92,7 +92,7 @@ class JSONRequestSerializer: XCTestCase {
         var header = result.allHTTPHeaderFields!["CUSTOM_HEADER"] as String
         
         XCTAssertNotNil(header)
-        XCTAssertEqual(header, "a value")
+        XCTAssertTrue(header == "a value", "header should match")
     }
     
     func testHeadersShouldExistOnRequestWhenPOST() {
@@ -103,6 +103,6 @@ class JSONRequestSerializer: XCTestCase {
         var header = result.allHTTPHeaderFields!["CUSTOM_HEADER"] as String
         
         XCTAssertNotNil(header)
-        XCTAssertEqual(header, "a value")
+        XCTAssertTrue(header == "a value", "header should match")
     }
 }


### PR DESCRIPTION
switching to ```XCTAssertTrue``` assertion when comparing solve the test failure. Seems to be some buggy optimisation that causes test case to fail if XCTAssertEqual is used. In the following code, ```testExample1``` succeeds and ```testExample2``` fails although they are identical code.

 My search on the net haven't revealed something concrete reasoning apart from some suggestions to switch to ```XCTAssertTrue``` [1].

--
    func testExample1() {
        XCTAssertEqual("foobar", "foobar")
    }
    func testExample2() {
        XCTAssertEqual("foobar", "foobar")
    }
--

[1] http://www.raywenderlich.com/forums/viewtopic.php?f=37&t=9475

