### PR TITLE
customizable http response

### DIFF
--- a/AeroGearHttp/Http.swift
+++ b/AeroGearHttp/Http.swift
@@ -463,29 +463,18 @@ public class Http {
                 return
             }
             
-
+            
             let response = task.response as! NSHTTPURLResponse
-            if #available(iOS 8, *) {
-                if  let _ = task as? NSURLSessionDownloadTask {
-                    completionHandler?(response, error)
-                    return
-                }
-            } else {
-                // in iOS7 we need more than just casting, we actually check the method is there ie: it's iOS7+
-                let downloadTask = task as? NSURLSessionDownloadTask
-                if  downloadTask != nil {
-                    if downloadTask!.respondsToSelector(Selector("cancelByProducingResumeData:")) {
-                        completionHandler?(response, error)
-                        return
-                    }
-                }
+            if  let _ = task as? NSURLSessionDownloadTask {
+                completionHandler?(response, error)
+                return
             }
             
             var responseObject: AnyObject? = nil
             do {
                 if let data = data {
                     try self.responseSerializer?.validateResponse(response, data)
-                    responseObject = self.responseSerializer?.response(data)
+                    responseObject = self.responseSerializer?.response(data, response.statusCode)
                     completionHandler?(responseObject, nil)
                 }
             } catch let error as NSError {

--- a/AeroGearHttp/Http.swift
+++ b/AeroGearHttp/Http.swift
@@ -478,7 +478,10 @@ public class Http {
                     completionHandler?(responseObject, nil)
                 }
             } catch let error as NSError {
-                completionHandler?(responseObject, error)
+                var userInfo = error.userInfo
+                userInfo["StatusCode"] = response.statusCode
+                let errorToRethrow = NSError(domain: error.domain, code: error.code, userInfo: userInfo)
+                completionHandler?(responseObject, errorToRethrow)
             }
         }
     }

--- a/AeroGearHttp/JsonResponseSerializer.swift
+++ b/AeroGearHttp/JsonResponseSerializer.swift
@@ -58,7 +58,7 @@ public class JsonResponseSerializer : ResponseSerializer {
     
     :returns: the serialized response
     */
-    public func response(data: NSData) -> (AnyObject?) {
+    public var response: (NSData, Int) -> AnyObject? = { (data: NSData, Int) -> AnyObject? in
         do {
             return try NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions(rawValue: 0))
         } catch _ {
@@ -69,7 +69,16 @@ public class JsonResponseSerializer : ResponseSerializer {
     public init() {
     }
     
+    public init(validateResponse: (NSURLResponse!, NSData) throws -> Void, response: (NSData, Int) -> AnyObject?) {
+        self.validateResponse = validateResponse
+        self.response = response
+    }
+    
     public init(validateResponse: (NSURLResponse!, NSData) throws -> Void) {
         self.validateResponse = validateResponse
+    }
+    
+    public init(response: (NSData, Int) -> AnyObject?) {
+        self.response = response
     }
 }

--- a/AeroGearHttp/ResponseSerializer.swift
+++ b/AeroGearHttp/ResponseSerializer.swift
@@ -32,7 +32,7 @@ public protocol ResponseSerializer {
 
      :returns: the serialized response
     */
-    func response(data: NSData) -> (AnyObject?)
+    var response: (NSData, Int) -> AnyObject? {get set}
     
     /**
      Validate the response received. This is a cutomizable closure variable.

--- a/AeroGearHttp/StringResponseSerializer.swift
+++ b/AeroGearHttp/StringResponseSerializer.swift
@@ -26,7 +26,7 @@ public class StringResponseSerializer : ResponseSerializer {
     
     :returns: the serialized response
     */
-    public func response(data: NSData) -> (AnyObject?) {
+    public var response: (NSData, Int) -> AnyObject? = {(data: NSData, status: Int) -> (AnyObject?) in
         return NSString(data: data, encoding:NSUTF8StringEncoding)
     }
     
@@ -55,7 +55,16 @@ public class StringResponseSerializer : ResponseSerializer {
     public init() {
     }
     
+    public init(validateResponse: (NSURLResponse!, NSData) throws -> Void, response: (NSData, Int) -> AnyObject?) {
+        self.validateResponse = validateResponse
+        self.response = response
+    }
+    
     public init(validateResponse: (NSURLResponse!, NSData) throws -> Void) {
         self.validateResponse = validateResponse
+    }
+    
+    public init(response: (NSData, Int) -> AnyObject?) {
+        self.response = response
     }
 }

--- a/AeroGearHttpTests/RequestSerializerTest.swift
+++ b/AeroGearHttpTests/RequestSerializerTest.swift
@@ -62,7 +62,7 @@ class RequestSerializerTests: XCTestCase {
     func testStringResponseSerializer() {
         let serialiser = StringResponseSerializer()
         
-        let result: String? = serialiser.response("some text received".dataUsingEncoding(NSUTF8StringEncoding)!) as? String
+        let result: String? = serialiser.response("some text received".dataUsingEncoding(NSUTF8StringEncoding)!, 200) as? String
         XCTAssertTrue(result == "some text received")
     }
 }


### PR DESCRIPTION
This PR is to give more flexibility to the lib. It nows allows to customize the response send back from server to be able to include the http status code (if needed).