### PR TITLE
Replace deprecated substring(from: )

### DIFF
--- a/AeroGearHttp/Http.swift
+++ b/AeroGearHttp/Http.swift
@@ -586,7 +586,7 @@ open class Http {
         
         guard let finalURL = URL(string: baseURL!) else {return nil}
         if (url.hasPrefix("/")) {
-            url = url.substring(from: url.characters.index(url.startIndex, offsetBy: 1))
+            url = String(url.dropFirst())
         }
         
         return finalURL.appendingPathComponent(url);


### PR DESCRIPTION
Related issues:

* [AGIOS-565](https://issues.jboss.org/browse/AGIOS-565) - Remove deprecate warnings on aerogear-ios-http